### PR TITLE
Add "no-implicit-coercion"

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ module.exports = {
     'react/jsx-one-expression-per-line': ['off'], // <-- This one is a bit annoying
     'no-await-in-loop': ['off'], // <-- Let's disable it and see if it bites us
     'no-underscore-dangle': ['off'], // We use _ in almost all repos. See discussion here: https://github.com/transloadit/botty/pull/41#discussion_r738022104
+
     'no-implicit-coercion': [
       'error',
       {

--- a/index.js
+++ b/index.js
@@ -135,5 +135,6 @@ module.exports = {
     'react/jsx-one-expression-per-line': ['off'], // <-- This one is a bit annoying
     'no-await-in-loop': ['off'], // <-- Let's disable it and see if it bites us
     'no-underscore-dangle': ['off'], // We use _ in almost all repos. See discussion here: https://github.com/transloadit/botty/pull/41#discussion_r738022104
+    'no-implicit-coercion': ['error'],
   },
 }

--- a/index.js
+++ b/index.js
@@ -135,6 +135,11 @@ module.exports = {
     'react/jsx-one-expression-per-line': ['off'], // <-- This one is a bit annoying
     'no-await-in-loop': ['off'], // <-- Let's disable it and see if it bites us
     'no-underscore-dangle': ['off'], // We use _ in almost all repos. See discussion here: https://github.com/transloadit/botty/pull/41#discussion_r738022104
-    'no-implicit-coercion': ['error'],
+    'no-implicit-coercion': [
+      'error',
+      {
+        disallowTemplateShorthand: true,
+      },
+    ],
   },
 }


### PR DESCRIPTION
https://eslint.org/docs/rules/no-implicit-coercion

I find this rule useful as it prevents shorthand syntax that can be either difficult to read or understand.

To me it's always better to write

```js
new Date().getTime()
```

instead of

```js
+new Date()
```

or

```js
String(foo)
```

instead of

```js
`${foo}`
```

There are more characters on screen yes, but the intend is clearer and reading the code requires less understanding of JavaScript internals.

I know that @kvz and @tim-kos like using these syntax tricks a lot, so I don't expect this to go very easy.