### PR TITLE
Remove allowTemplateLiterals from quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,6 @@ module.exports = {
       'single',
       {
         avoidEscape: true,
-        allowTemplateLiterals: true,
       },
     ],
 


### PR DESCRIPTION
Bad:

```js
const str = `a string without interpolation`
```

Good:

```js
const str = 'a string without interpolation'
const str = `a string ${withInterpolation}`
```

This follows standard: https://github.com/standard/standard/issues/838
Eslint rule: https://eslint.org/docs/rules/quotes

The reason I would like to disallow template literals without interpolation is that it makes code harder to read, when your eyes are intuitively looking for the interpolation / where the string is dynamic.