### PR TITLE
remove dependency on `@babel/eslint-parser`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,19 +10,11 @@ module.exports = {
     node: true,
   },
   plugins: [
-    '@babel/eslint-plugin',
     'jest',
     'node',
     'promise',
     'react',
   ],
-  parser: '@babel/eslint-parser',
-  parserOptions: {
-    ecmaVersion: 2020,
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
   rules: {
     // Include rules from standard that are not in airbnb:
     // https://github.com/transloadit/node-sdk/issues/90


### PR DESCRIPTION
Not every repo needs Babel to run their linter (in fact, it's very possible that none does anymore); removing it here doesn't mean downstream repos can't use it anymore (they just need to specify the parser in their ESLint config).