### PR TITLE
Align assignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+.vscode/configurationCache.log
+.vscode/dryrun.log
+.vscode/targets.log

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
     'node',
     'promise',
     'react',
+    'align-assignments',
   ],
   rules: {
     // Include rules from standard that are not in airbnb:
@@ -61,6 +62,10 @@ module.exports = {
         message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
       },
     ],
+
+    // added features:
+    ////////////////////////////////////////////////////////////
+    'align-assignments/align-assignments': ['error', { requiresOnly: false }],
 
     // rules imported from the api repo:
     ////////////////////////////////////////////////////////////

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/eslint-parser": "^7.13.10",
     "@babel/eslint-plugin": "^7.13.10",
     "eslint": "^7.22.0",
+    "eslint-plugin-align-assignments": "^1.1.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -761,6 +761,11 @@ eslint-module-utils@^2.6.2:
     debug "^3.2.7"
     pkg-dir "^2.0.0"
 
+eslint-plugin-align-assignments@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-align-assignments/-/eslint-plugin-align-assignments-1.1.2.tgz#83e1a8a826d4adf29e82b52d0bb39c88b301b576"
+  integrity sha512-I1ZJgk9EjHfGVU9M2Ex8UkVkkjLL5Y9BS6VNnQHq79eHj2H4/Cgxf36lQSUTLgm2ntB03A2NtF+zg9fyi5vChg==
+
 eslint-plugin-es@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"


### PR DESCRIPTION
This is already how much of our js is written, but now it can be autofixed with this eslint plugin.

As an example in the content repo, here's how that looks: https://github.com/transloadit/content/commit/b92d614f0db74c84b769e4484448236cbb263e69, and a screenshot:

![image](https://user-images.githubusercontent.com/26752/196465140-d90b60af-4c90-41e5-aeca-4ce72c573208.png)

In my mind, for the same reason why tables were invented, this is quicker to parse.

In addition, it exposes when lines don't really belong together, because it suddenly looks weird when you see things that do not belong together vertically aligned in the same way, the quick fix there being to add a newline to separate logically different blocks, further enhancing parseability. Finally if there are many identical calls as with the screenshot above, it is easier to spot if some line diverges.

With respects to the downside of: "this makes diffs harder", if everyone has their code auto-fixed in their editor before pushing, that problem is much smaller. Then in addition when you enable "Hide Whitepace" in PRs on GitHub, the problem goes away:

![image](https://user-images.githubusercontent.com/26752/196462244-e81662bb-f236-4124-9073-599d6bbe84bd.png)

